### PR TITLE
refactor: Remove reload option in uvicorn.run() call

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,4 +23,4 @@ def create_app():
 if __name__ == '__main__':
     import uvicorn
     app = create_app()
-    uvicorn.run(app, host="0.0.0.0", port=8080, reload=True)
+    uvicorn.run(app, host="0.0.0.0", port=8080)


### PR DESCRIPTION
Removed the reload option in uvicorn.run() call to prevent automatic server
reloading. This option is not possible when launching using a an app instance over an import string.